### PR TITLE
[VP-6676] fix permissions for the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ jobs:
   publish:
     name: Publish package
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

Broke the publish pipeline with my latest changes, this will fix it.

## Changes

Added permissions to the publish pipeline to create releases, push tags, all that good stuff.

## Testing

Can't test :(

---

I have gone over the [contributing](https://github.com/DataDog/rum-react-integration/blob/master/CONTRIBUTING.md) documentation.
